### PR TITLE
Delegate playlist related methods to Spotify::Playlist object

### DIFF
--- a/lib/spotify/playlist.rb
+++ b/lib/spotify/playlist.rb
@@ -52,7 +52,7 @@ module Spotify
     # Adding tracks to a user's public playlist requires authorization of the playlist-modify-public scope;
     # adding tracks to a private playlist requires the playlist-modify-private scope.
     #
-    # client.add_tracks(%w(spotify:track:4iV5W9uYEdYUVa79Axb7Rh spotify:track:2lzEz3A3XIFyhMDqzMdcss))
+    # playlist.add_tracks(%w(spotify:track:4iV5W9uYEdYUVa79Axb7Rh spotify:track:2lzEz3A3XIFyhMDqzMdcss))
     def add_tracks(uris=[], position=nil)
       params = { uris: Array.wrap(uris)[0..99].join(',') }
       if position
@@ -63,14 +63,14 @@ module Spotify
 
     # Replaces all occurrences of tracks with what's in the playlist
     #
-    # client.replace_user_tracks_in_playlist('1181346016', '7i3thJWDtmX04dJhFwYb0x', %w(spotify:track:4iV5W9uYEdYUVa79Axb7Rh spotify:track:2lzEz3A3XIFyhMDqzMdcss))
+    # playlist.replace_tracks(%w(spotify:track:4iV5W9uYEdYUVa79Axb7Rh spotify:track:2lzEz3A3XIFyhMDqzMdcss))
     def replace_tracks(tracks)
       client.run(:put, "/v1/users/#{user_id}/playlists/#{id}/tracks", [201], JSON.dump(uris: tracks))
     end
 
     # Removes all tracks in playlist
     #
-    # client.truncate_user_playlist('1181346016', '7i3thJWDtmX04dJhFwYb0x')
+    # playlist.truncate
     def truncate
       replace_tracks([])
     end

--- a/lib/spotify/playlist.rb
+++ b/lib/spotify/playlist.rb
@@ -65,14 +65,14 @@ module Spotify
     #
     # client.replace_user_tracks_in_playlist('1181346016', '7i3thJWDtmX04dJhFwYb0x', %w(spotify:track:4iV5W9uYEdYUVa79Axb7Rh spotify:track:2lzEz3A3XIFyhMDqzMdcss))
     def replace_tracks(tracks)
-      run(:put, "/v1/users/#{user_id}/playlists/#{id}/tracks", [201], JSON.dump(uris: tracks))
+      client.run(:put, "/v1/users/#{user_id}/playlists/#{id}/tracks", [201], JSON.dump(uris: tracks))
     end
 
     # Removes all tracks in playlist
     #
     # client.truncate_user_playlist('1181346016', '7i3thJWDtmX04dJhFwYb0x')
     def truncate
-      replace_user_tracks_in_playlist(user_id, id, [])
+      replace_tracks([])
     end
   end
 end

--- a/lib/spotify/playlist.rb
+++ b/lib/spotify/playlist.rb
@@ -1,0 +1,78 @@
+module Spotify
+  class Playlist
+
+    FIELDS = %w{ collaborative description external_urls href id name owner
+                 public snapshot_id type uri }
+
+    FIELDS.each do |f|
+      attr_accessor f.to_sym
+    end
+    attr_accessor :client
+
+    def initialize(client, options={})
+      @client = client
+
+      attributes(options)
+    end
+
+    def attributes(options)
+      options.each do |key, val|
+        key = key.to_s if key.is_a?(String)
+        next unless FIELDS.include?(key)
+        send("#{key}=", val)
+      end
+    end
+
+    def user_id
+      @user_id ||= client.me['id']
+    end
+
+    def fetch
+      if id
+        response =
+          client.run(:get, "/v1/users/#{user_id}/playlists/#{id}", [200])
+
+        attributes(response)
+      end
+    end
+
+    # Create a playlist for a Spotify user. The playlist will be empty until you add tracks.
+    #
+    # Requires playlist-modify-public for a public playlist.
+    # Requires playlist-modify-private for a private playlist.
+    def self.create(client, name, is_public = true)
+      user_id = client.me['id']
+      response =
+        client.run(:post, "/v1/users/#{user_id}/playlists", [201], JSON.dump(name: name, public: is_public), false)
+      new(client, response)
+    end
+
+    # Add an Array of track uris to an existing playlist.
+    #
+    # Adding tracks to a user's public playlist requires authorization of the playlist-modify-public scope;
+    # adding tracks to a private playlist requires the playlist-modify-private scope.
+    #
+    # client.add_tracks(%w(spotify:track:4iV5W9uYEdYUVa79Axb7Rh spotify:track:2lzEz3A3XIFyhMDqzMdcss))
+    def add_tracks(uris=[], position=nil)
+      params = { uris: Array.wrap(uris)[0..99].join(',') }
+      if position
+        params.merge!(position: position)
+      end
+      client.run(:post, "/v1/users/#{user_id}/playlists/#{id}/tracks", [201], params, false)
+    end
+
+    # Replaces all occurrences of tracks with what's in the playlist
+    #
+    # client.replace_user_tracks_in_playlist('1181346016', '7i3thJWDtmX04dJhFwYb0x', %w(spotify:track:4iV5W9uYEdYUVa79Axb7Rh spotify:track:2lzEz3A3XIFyhMDqzMdcss))
+    def replace_tracks(tracks)
+      run(:put, "/v1/users/#{user_id}/playlists/#{id}/tracks", [201], JSON.dump(uris: tracks))
+    end
+
+    # Removes all tracks in playlist
+    #
+    # client.truncate_user_playlist('1181346016', '7i3thJWDtmX04dJhFwYb0x')
+    def truncate
+      replace_user_tracks_in_playlist(user_id, id, [])
+    end
+  end
+end

--- a/lib/spotify/playlist.rb
+++ b/lib/spotify/playlist.rb
@@ -17,7 +17,7 @@ module Spotify
 
     def attributes(options)
       options.each do |key, val|
-        key = key.to_s if key.is_a?(String)
+        key = key.to_s if key.is_a?(Symbol)
         next unless FIELDS.include?(key)
         send("#{key}=", val)
       end

--- a/lib/spotify/playlist.rb
+++ b/lib/spotify/playlist.rb
@@ -36,7 +36,8 @@ module Spotify
       end
     end
 
-    # Create a playlist for a Spotify user. The playlist will be empty until you add tracks.
+    # Create a playlist for a Spotify user. The playlist will be empty until
+    # you add tracks.
     #
     # Requires playlist-modify-public for a public playlist.
     # Requires playlist-modify-private for a private playlist.
@@ -49,8 +50,9 @@ module Spotify
 
     # Add an Array of track uris to an existing playlist.
     #
-    # Adding tracks to a user's public playlist requires authorization of the playlist-modify-public scope;
-    # adding tracks to a private playlist requires the playlist-modify-private scope.
+    # Adding tracks to a user's public playlist requires authorization of the
+    # playlist-modify-public scope; adding tracks to a private playlist
+    # requires the playlist-modify-private scope.
     #
     # playlist.add_tracks(%w(spotify:track:4iV5W9uYEdYUVa79Axb7Rh spotify:track:2lzEz3A3XIFyhMDqzMdcss))
     def add_tracks(uris=[], position=nil)
@@ -59,6 +61,26 @@ module Spotify
         params.merge!(position: position)
       end
       client.run(:post, "/v1/users/#{user_id}/playlists/#{id}/tracks", [201], params, false)
+    end
+
+    # Get full details of the tracks of a playlist owned by user
+    def tracks(params={})
+      tracks = { 'items' => [] }
+      path = "/v1/users/#{user_id}/playlists/#{id}/tracks"
+
+      while path
+        response = client.run(:get, path, [200], params)
+        tracks['items'].concat(response.delete('items'))
+        tracks.merge!(response)
+
+        path = if response['next']
+          response['next'].gsub(Spotify::Client::BASE_URI, '')
+        else
+          nil
+        end
+      end
+
+      tracks
     end
 
     # Replaces all occurrences of tracks with what's in the playlist

--- a/spec/lib/spotify/playlist_spec.rb
+++ b/spec/lib/spotify/playlist_spec.rb
@@ -28,6 +28,7 @@ describe Spotify::Playlist do
     end
 
     subject { Spotify::Playlist.create(client, 'Mola test') }
+
     it "returns playlist instance" do
       expect(subject).to be_instance_of(Spotify::Playlist)
     end

--- a/spec/lib/spotify/playlist_spec.rb
+++ b/spec/lib/spotify/playlist_spec.rb
@@ -1,0 +1,35 @@
+require './lib/spotify/playlist'
+
+describe Spotify::Playlist do
+  let(:client) { double(:client, me: { 'id' => 123 }) }
+
+  describe '#initialize' do
+    let(:fixture) { request_fixture('playlist') }
+
+    it "returns value of valid attribute" do
+      data = JSON.parse(fixture)
+      playlist = Spotify::Playlist.new(client, data)
+      expect(playlist.collaborative).to eq data["collaborative"]
+      expect(playlist.public).to eq data["public"]
+      expect(playlist.name).to eq data["name"]
+    end
+
+    it "raises an error on invalid field" do
+      playlist = Spotify::Playlist.new(client, xxx: 'xxx')
+      expect(playlist.respond_to?(:xxx)).to eq false
+    end
+  end
+
+  describe ".create" do
+    let(:fixture) { request_fixture('playlist') }
+
+    before do
+      allow(client).to receive(:run).and_return JSON.parse(fixture)
+    end
+
+    subject { Spotify::Playlist.create(client, 'Mola test') }
+    it "returns playlist instance" do
+      expect(subject).to be_instance_of(Spotify::Playlist)
+    end
+  end
+end


### PR DESCRIPTION
``` ruby
client = Spotify::Client.new(access_token: 'yourtoken')
# create new playlist
playlist = Spotify::Playlist.create(client, 'Playlist name', false)

playlist = Spotify::Playlist.new(client, 'id' => 'playlistid')

# get existing playlist from a given ID
playlist.fetch

# add tracks
playlist.add_tracks([track_uri])
```
