### PR TITLE
Fix artists endpoint

### DIFF
--- a/lib/spotify_client.rb
+++ b/lib/spotify_client.rb
@@ -146,7 +146,7 @@ module Spotify
 
     def artists(artist_ids)
       params = { ids: Array.wrap(artist_ids).join(',') }
-      run(:get, '/v1/tracks', [200], params)
+      run(:get, '/v1/artists', [200], params)
     end
 
     def artist_albums(artist_id)


### PR DESCRIPTION
Hey, awesome gem!  I noticed there was a typo in the artists method.  It was hitting the `/v1/tracks` endpoint.  I changed it, and it's working now!  :tada: 