### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,24 @@ This feature is not supported (yet) by this gem, but if you'd like to let users 
 ## License
 
 Please refer to [LICENSE.md](https://github.com/icoretech/spotify-client/blob/master/LICENSE).
+
+<div style="margin: 25px;">
+<a href="https://rapidapi.com/package/SpotifyPublicAPI/functions?utm_source=SpotifyGitHub&utm_medium=button&utm_content=Vendor_GitHub" style="
+    all: initial;
+    background-color: #498FE1;
+    border-width: 0;
+    border-radius: 5px;
+    padding: 10px 20px;
+    color: white;
+    font-family: 'Helvetica';
+    font-size: 12pt;
+    background-image: url(https://scdn.rapidapi.com/logo-small.png);
+    background-size: 25px;
+    background-repeat: no-repeat;
+    background-position-y: center;
+    background-position-x: 10px;
+    padding-left: 44px;
+    cursor: pointer;">
+  Test on <b>RapidAPI</b>
+</a>
+</div>


### PR DESCRIPTION
Hey! I've added a link in your README to Spotify's functions page in RapidAPI. I've done this for a few Spotify SDKs to help those who are reading the READMEs, understand and test the API before use.