### PR TITLE
Add ability to specify search parameters

### DIFF
--- a/lib/spotify_client.rb
+++ b/lib/spotify_client.rb
@@ -162,11 +162,15 @@ module Spotify
       run(:get, "/v1/artists/#{artist_id}/albums", [200])
     end
 
-    def search(entity, term)
+    def search(entity, term, options={})
       unless [:artist, :album, :track].include?(entity.to_sym)
         fail(ImplementationError, "entity needs to be either artist, album or track, got: #{entity}")
       end
-      run(:get, '/v1/search', [200], q: term.to_s, type: entity)
+      params = {
+        q: term.to_s,
+        type: entity
+      }.merge(options)
+      run(:get, '/v1/search', [200], params)
     end
 
     # Get Spotify catalog information about an artist's top 10 tracks by country.

--- a/spec/lib/spotify_client_spec.rb
+++ b/spec/lib/spotify_client_spec.rb
@@ -157,4 +157,12 @@ describe Spotify::Client do
       # expect(response['tracks']).to be_a(Array)
     end
   end
+
+  describe ".search" do
+    it "should pass additional options as search parameters" do
+      Excon.stub({ :method => :get, :path => "/v1/search" }, { :status => 200 })
+      expect(authenticated_client).to receive(:run).with(any_args, hash_including(q: "bob", limit: 5))
+      authenticated_client.search(:artist, "bob", limit: 5)
+    end
+  end
 end


### PR DESCRIPTION
This will allow you to pass any additional parameters when searching, like limit for instance:
```ruby
client.search(:artist, "bob", limit: 5)
```